### PR TITLE
kind/cleanup: workload identity checks also when grabbing config from secret

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -985,6 +985,26 @@ func (az *Cloud) getAzureClientConfig(servicePrincipalToken *adal.ServicePrincip
 	return azClientConfig
 }
 
+func configChecks(config Config) *Config {
+	// The resource group name may be in different cases from different Azure APIs, hence it is converted to lower here.
+	// See more context at https://github.com/kubernetes/kubernetes/issues/71994.
+	config.ResourceGroup = strings.ToLower(config.ResourceGroup)
+
+	// these environment variables are injected by workload identity webhook
+	if tenantID := os.Getenv("AZURE_TENANT_ID"); tenantID != "" {
+		config.TenantID = tenantID
+	}
+	if clientID := os.Getenv("AZURE_CLIENT_ID"); clientID != "" {
+		config.AADClientID = clientID
+	}
+	if federatedTokenFile := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); federatedTokenFile != "" {
+		config.AADFederatedTokenFile = federatedTokenFile
+		config.UseFederatedWorkloadIdentityExtension = true
+	}
+
+	return &config
+}
+
 // ParseConfig returns a parsed configuration for an Azure cloudprovider config file
 func ParseConfig(configReader io.Reader) (*Config, error) {
 	var config Config
@@ -1002,22 +1022,9 @@ func ParseConfig(configReader io.Reader) (*Config, error) {
 		return nil, err
 	}
 
-	// The resource group name may be in different cases from different Azure APIs, hence it is converted to lower here.
-	// See more context at https://github.com/kubernetes/kubernetes/issues/71994.
-	config.ResourceGroup = strings.ToLower(config.ResourceGroup)
+	configChecked := configChecks(config)
 
-	// these environment variables are injected by workload identity webhook
-	if tenantID := os.Getenv("AZURE_TENANT_ID"); tenantID != "" {
-		config.TenantID = tenantID
-	}
-	if clientID := os.Getenv("AZURE_CLIENT_ID"); clientID != "" {
-		config.AADClientID = clientID
-	}
-	if federatedTokenFile := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); federatedTokenFile != "" {
-		config.AADFederatedTokenFile = federatedTokenFile
-		config.UseFederatedWorkloadIdentityExtension = true
-	}
-	return &config, nil
+	return configChecked, nil
 }
 
 func (az *Cloud) isStackCloud() bool {

--- a/pkg/provider/azure_config.go
+++ b/pkg/provider/azure_config.go
@@ -86,5 +86,7 @@ func (az *Cloud) GetConfigFromSecret() (*Config, error) {
 		return nil, fmt.Errorf("failed to parse Azure cloud-config: %w", err)
 	}
 
-	return &config, nil
+	configChecked := configChecks(config)
+
+	return configChecked, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
When running the kubernetes-sigs/blob-csi-driver code on a self-managed kubernetes cluster, I created a cloud
config with a secret. However, since the cloud config just gets retrieved from the secret and immediately starts trying to initialize, it doesn't walkthrough the code that sets up the workload identity

#### Does this PR introduce a user-facing change?
```release-note
configuration schema change
```
